### PR TITLE
Dynamically determine provider

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -16,16 +16,20 @@ class Cache extends BaseCache
 
     public function read($file)
     {
-      $content = parent::read($file);
-        if (0 === strpos($file, 'provider-symfony$')) {
-            $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
+        $content = parent::read($file);
+        foreach (array_keys(self::$lowestTags) as $key) {
+            list($provider, ) = explode('/', $key, 2);
+            if (0 === strpos($file, "provider-$provider\$")) {
+                $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
+                break;
+            }
         }
         return $content;
     }
 
     public function removeLegacyTags(array $data): array
     {
-      foreach (self::$lowestTags as $package => $lowestVersion) {
+        foreach (self::$lowestTags as $package => $lowestVersion) {
             if (!isset($data['packages'][$package][$lowestVersion])) {
                 continue;
             }


### PR DESCRIPTION
^ in case multiple packages by different vendors are added to `protected static $lowestTags`.

Tested on:
```
        'drupal/core' => '8.5.0',
        'doctrine/common' => 'v2.5.0',
        'doctrine/annotations' => 'v1.2.0',
        'twig/twig' => 'v1.35.0',
        'guzzlehttp/guzzle' => '6.2.1',
        'drush/drush' => '9.0.0',
```
but gives only 25MB memory boost for default setup (drupal/drupal) and no boost time-wise, hence skipping it for now.