### PR TITLE
Remove dependency on Drupal core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.1",
-        "drupal/core": "^8.5"
+        "composer-plugin-api": "^1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There is really nothing in this plugin requiring Drupal core. I understand the need to specify it to make it possible to use with old versions of Drupal, but this plugin can be used with any project, really. Unless said project uses symfony < 3.4. Heck it can even be used as a global composer plugin, and make all things so much better. Which is why it seems not ideal to require drupal core, since that would install drupal core globally for me, so to speak.

Quick PR to remove Drupal core. Let me know what you think. Probably makes more sense to do together with making it possible to specify lowest as a config option.