### PR TITLE
Fix fatal error when parent fails to read the file

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -17,16 +17,17 @@ class Cache extends BaseCache
     public function read($file)
     {
         $content = parent::read($file);
-        if ($content) {
-            foreach (array_keys(self::$lowestTags) as $key) {
-                list($provider, ) = explode('/', $key, 2);
-                if (0 === strpos($file, "provider-$provider\$")) {
-                    $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
-                    break;
-                }
+        if (!\is_array($data = json_decode($content, true))) {
+            return $content;
+        }
+        foreach (array_keys(self::$lowestTags) as $key) {
+            list($provider, ) = explode('/', $key, 2);
+            if (0 === strpos($file, "provider-$provider\$")) {
+                $data = $this->removeLegacyTags($data);
+                break;
             }
         }
-        return $content;
+        return json_encode($data);
     }
 
     public function removeLegacyTags(array $data)

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -17,11 +17,13 @@ class Cache extends BaseCache
     public function read($file)
     {
         $content = parent::read($file);
-        foreach (array_keys(self::$lowestTags) as $key) {
-            list($provider, ) = explode('/', $key, 2);
-            if (0 === strpos($file, "provider-$provider\$")) {
-                $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
-                break;
+        if ($content) {
+            foreach (array_keys(self::$lowestTags) as $key) {
+                list($provider, ) = explode('/', $key, 2);
+                if (0 === strpos($file, "provider-$provider\$")) {
+                    $content = json_encode($this->removeLegacyTags(json_decode($content, true)));
+                    break;
+                }
             }
         }
         return $content;


### PR DESCRIPTION
There are a couple conditions where the parent cache would return a falsy value when reading and when it does there is nothing for the optimization to do but skip its logic and return the falsy value.