### PR TITLE
Feature request: Use hirak/prestissimo for faster composer installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: RELEASE=stable COMPOSER_CHANNEL=snapshot
 
 before_install:
+  # Installing hirak/prestissimo allows composer to parallelise downloads which speeds up the composer install.
+  - composer global require hirak/prestissimo
   - if [[ $TRAVIS_PHP_VERSION = 5.6 ]]; then export COMPOSER_MEMORY_LIMIT=-1; fi;
   - composer --verbose self-update --$COMPOSER_CHANNEL
   - composer --version

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "composer-plugin-api": "^1.1",
-        "drupal/core": "^8.5"
+        "drupal/core": "^8.5",
+        "hirak/prestissimo": "^0.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The package parallelises downloads ahead of time instead of downloading packages one by one. This can speed up package installs by about 60-80%.