### PR TITLE
Fixes #16: Support Composer 2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.6",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,6 +54,14 @@ class Plugin implements PluginInterface
         $composer->setRepositoryManager($manager);
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
     /**
      * Negotiates default require constraint and package for given drupal/core.
      *

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,13 @@ class Plugin implements PluginInterface
 
     public function activate(Composer $composer, IOInterface $io)
     {
+        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '<=')) {
+            if ($io->isVerbose()) {
+                $io->write(sprintf('zaporylie/composer-drupal-optimizations is disabled for Composer 2'));
+            }
+            // Return early.
+            return;
+        }
         // Set default version constraints based on the composer requirements.
         $extra = $composer->getPackage()->getExtra();
         $packages = $composer->getPackage()->getRequires();


### PR DESCRIPTION
Fixes #16 

This is just a draft and known to be incomplete. At a minimum, Composer's RemoteFilesystem no longer exists, you need to switch to the HttpDownloader instead. There may be other issues as well.

You should follow the upgrade guide and test to ensure it works as expected: https://github.com/composer/composer/issues/8726

However, I'm actually not sure if this plugin is even needed with Composer 2. Maybe it would be better to deprecate it? Check out these benchmarks for an install with Drupal core:

Composer 1 without Composer Drupal Optimizations
> Memory usage: 424.89MiB (peak: 1133.92MiB), time: 18.24s

Composer 1 with Composer Drupal Optimizations
> Memory usage: 342.13MiB (peak: 459.25MiB), time: 8.43s

Composer 2 without Composer Drupal Optimizations
> Memory usage: 21.84MiB (peak: 135.12MiB), time: 9.57s

As you can see, Composer 2 without this plugin is an order of magnitude more efficient than even Composer 1 _with_ the plugin. Porting this plugin to Composer 2 might make those numbers even better, but I'm not sure how much so.