### PR TITLE
Check if the extra key exists on the composer.json before accessing it

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -72,7 +72,7 @@ class Cache extends BaseCache
             $packages = [];
             $specificPackage = $data['packages'][$packageName];
             foreach ($specificPackage as $version => $composerJson) {
-                if ('dev-master' === $version) {
+                if ('dev-master' === $version && isset($composerJson['extra'])) {
                     $normalizedVersion = $this->versionParser->normalize($composerJson['extra']['branch-alias']['dev-master']);
                 } else {
                     $normalizedVersion = $composerJson['version_normalized'];


### PR DESCRIPTION
Hey there

We ran into the problem where all projects we used couldn't be installed anymore, throwing an exception telling us that the 'extra' key does not exist.

I added a check to validate that the extra key does exist before trying to use it which fixed the problem for us